### PR TITLE
fix conn.getToken not function

### DIFF
--- a/packages/amazonq/package.json
+++ b/packages/amazonq/package.json
@@ -180,13 +180,13 @@
                     "type": "webview",
                     "id": "aws.amazonq.AmazonCommonAuth",
                     "name": "%AWS.amazonq.login%",
-                    "when": "!isCloud9 && !aws.isSageMaker && !aws.codewhisperer.connected"
+                    "when": "!isCloud9 && !aws.isSageMaker && !aws.amazonq.hasConnections"
                 },
                 {
                     "type": "webview",
                     "id": "aws.AmazonQChatView",
                     "name": "%AWS.amazonq.chat%",
-                    "when": "!isCloud9 && !aws.isSageMaker && aws.codewhisperer.connected"
+                    "when": "!isCloud9 && !aws.isSageMaker && aws.amazonq.hasConnections"
                 },
                 {
                     "id": "aws.AmazonQNeverShowBadge",

--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -18,7 +18,7 @@ import {
     globals,
     RegionProvider,
 } from 'aws-core-vscode/shared'
-import { Auth, initializeAuth } from 'aws-core-vscode/auth'
+import { initializeAuth } from 'aws-core-vscode/auth'
 import { makeEndpointsProvider } from 'aws-core-vscode'
 import { activate as activateCWChat } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
@@ -68,10 +68,6 @@ export async function activateShared(context: vscode.ExtensionContext) {
     if (isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
         void vscode.commands.executeCommand('aws.amazonq.refresh')
     }
-
-    // only display the login screen if there is no connections at all
-    // if there are connections, use can re-auth from status bar or q chat.
-    await vscode.commands.executeCommand('setContext', 'aws.amazonq.hasConnections', Auth.instance.hasConnections)
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')

--- a/packages/amazonq/src/extensionShared.ts
+++ b/packages/amazonq/src/extensionShared.ts
@@ -18,7 +18,7 @@ import {
     globals,
     RegionProvider,
 } from 'aws-core-vscode/shared'
-import { initializeAuth } from 'aws-core-vscode/auth'
+import { Auth, initializeAuth } from 'aws-core-vscode/auth'
 import { makeEndpointsProvider } from 'aws-core-vscode'
 import { activate as activateCWChat } from 'aws-core-vscode/amazonq'
 import { activate as activateQGumby } from 'aws-core-vscode/amazonqGumby'
@@ -68,6 +68,10 @@ export async function activateShared(context: vscode.ExtensionContext) {
     if (isExtensionActive(VSCODE_EXTENSION_ID.awstoolkit)) {
         void vscode.commands.executeCommand('aws.amazonq.refresh')
     }
+
+    // only display the login screen if there is no connections at all
+    // if there are connections, use can re-auth from status bar or q chat.
+    await vscode.commands.executeCommand('setContext', 'aws.amazonq.hasConnections', Auth.instance.hasConnections)
 
     // reload webviews
     await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction')

--- a/packages/core/src/codewhisperer/util/authUtil.ts
+++ b/packages/core/src/codewhisperer/util/authUtil.ts
@@ -167,6 +167,11 @@ export class AuthUtil {
                 'aws.codewhisperer.connectionExpired',
                 this.isConnectionExpired()
             )
+            await vscode.commands.executeCommand(
+                'setContext',
+                'aws.amazonq.hasConnections',
+                Auth.instance.hasConnections
+            )
         }
     }
 

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -53,21 +53,14 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
                 const connections: SsoConnection[] = await importedApi?.listConnections()
                 connections.forEach(async (connection: SsoConnection) => {
                     if (connection.id === connectionId) {
-                        if (connection.scopes?.includes('codewhisperer:completions')) {
-                            getLogger().info(`auth: re-use connection ${connectionId} from aws toolkit`)
-                            await AuthUtil.instance.secondaryAuth.useNewConnection(connection)
-                            await AuthUtil.instance.restore()
-                        } else {
-                            getLogger().info(`auth: re-authenticate for adding new AmazonQ scopes`)
-                            // create new connection with amazon q scopes
-                            const conn = await Auth.instance.createConnection({
-                                type: connection.type,
-                                ssoRegion: connection.ssoRegion,
-                                startUrl: connection.startUrl,
-                                scopes: amazonQScopes,
-                            })
-                            await AuthUtil.instance.secondaryAuth.useNewConnection(conn)
-                        }
+                        getLogger().info(`auth: create connection from existing connection id ${connectionId}`)
+                        const conn = await Auth.instance.createConnection({
+                            type: connection.type,
+                            ssoRegion: connection.ssoRegion,
+                            startUrl: connection.startUrl,
+                            scopes: amazonQScopes,
+                        })
+                        await AuthUtil.instance.secondaryAuth.useNewConnection(conn)
                     }
                 })
             }


### PR DESCRIPTION
## Problem

1. Fix conn.getToken  function not defined issue.

2. Let Amazon Q use a new context key that controls whether its login screen should be displayed or not. 

## Solution

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
