### PR TITLE
Do not allow re-creating connection with same start url

### DIFF
--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -12,7 +12,7 @@ import { CancellationError } from '../../../shared/utilities/timeoutUtils'
 import { trustedDomainCancellation } from '../../../auth/sso/model'
 import { handleWebviewError } from '../../../webviews/server'
 import { InvalidGrantException } from '@aws-sdk/client-sso-oidc'
-import { SsoConnection } from '../../../auth/connection'
+import { Connection, SsoConnection } from '../../../auth/connection'
 import { Auth } from '../../../auth/auth'
 import { StaticProfile, StaticProfileKeyErrorMessage } from '../../../auth/credentials/types'
 
@@ -110,4 +110,8 @@ export abstract class CommonAuthWebview extends VueWebview {
     abstract useConnection(connectionId: string): Promise<AuthError | undefined>
 
     abstract errorNotification(e: AuthError): void
+
+    async listConnections(): Promise<Connection[]> {
+        return Auth.instance.listConnections()
+    }
 }


### PR DESCRIPTION
## Problem

Connections can be duplicated by signing in with same connection start url. 

## Solution

Do not allow re-creating connection with same start url. This is exactly what existing old login flow does.
<img width="580" alt="Screenshot 2024-03-25 at 12 18 15 PM" src="https://github.com/hayemaxi/aws-toolkit-vscode/assets/97199248/dca12ed4-7b49-4c5f-9364-3d07fca57861">
<img width="558" alt="Screenshot 2024-03-25 at 12 18 03 PM" src="https://github.com/hayemaxi/aws-toolkit-vscode/assets/97199248/82d529a8-e47c-4dda-9d75-ccd2be91548c">


<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
