### PR TITLE
Add back arrow at login start screen

### DIFF
--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -114,7 +114,5 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
         throw new Error('Method not implemented.')
     }
 
-    async quitLoginScreen() {
-        throw new Error('Method not implemented.')
-    }
+    async quitLoginScreen() {}
 }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -113,4 +113,8 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     ): Promise<AuthError | undefined> {
         throw new Error('Method not implemented.')
     }
+
+    async quitLoginScreen() {
+        await vscode.commands.executeCommand('setContext', 'aws.amazonq.showAuthView', false)
+    }
 }

--- a/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
+++ b/packages/core/src/login/webview/vue/amazonq/backend_amazonq.ts
@@ -115,6 +115,6 @@ export class AmazonQLoginWebview extends CommonAuthWebview {
     }
 
     async quitLoginScreen() {
-        await vscode.commands.executeCommand('setContext', 'aws.amazonq.showAuthView', false)
+        throw new Error('Method not implemented.')
     }
 }

--- a/packages/core/src/login/webview/vue/backend.ts
+++ b/packages/core/src/login/webview/vue/backend.ts
@@ -114,4 +114,6 @@ export abstract class CommonAuthWebview extends VueWebview {
     async listConnections(): Promise<Connection[]> {
         return Auth.instance.listConnections()
     }
+
+    abstract quitLoginScreen(): Promise<void>
 }

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -72,7 +72,7 @@
             </svg>
         </div>
         <template v-if="stage === 'START'">
-            <button class="back-button" @click="handleBackButtonClick">
+            <button class="back-button" v-if="app === 'TOOLKIT'" @click="handleBackButtonClick">
                 <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path
                         d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
@@ -140,6 +140,14 @@
                     />
                 </svg>
             </button>
+            <div class="code-catalyst-login" v-if="app === 'TOOLKIT'">
+                <div class="h4">
+                    Using CodeCatalyst with AWS Builder ID?
+                    <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
+                </div>
+                <br /><br />
+            </div>
+
             <div class="auth-container-section">
                 <div class="title">Sign in with SSO:</div>
                 <div class="p">Start URL</div>
@@ -192,12 +200,7 @@
             </button>
             <div class="title">IAM Credentials:</div>
             <div class="hint">Credentials will be added to the appropriate ~/.aws/ files</div>
-            <div class="h4">
-                Using CodeCatalyst with AWS Builder ID?
-                <a href="#" @click="handleCodeCatalystSignin()">Skip to sign-in</a>
-            </div>
 
-            <br /><br />
             <br /><br />
             <div class="p">Profile Name</div>
             <div class="hint">The identifier for these credentials</div>
@@ -456,7 +459,7 @@ export default defineComponent({
     color: white;
 }
 .h4 {
-    font-size: 8px;
+    font-size: 10px;
 }
 .continue-button:disabled {
     background-color: #252526;

--- a/packages/core/src/login/webview/vue/login.vue
+++ b/packages/core/src/login/webview/vue/login.vue
@@ -72,6 +72,14 @@
             </svg>
         </div>
         <template v-if="stage === 'START'">
+            <button class="back-button" @click="handleBackButtonClick">
+                <svg width="13" height="11" viewBox="0 0 13 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M4.98667 0.0933332L5.73333 0.786666L1.57333 4.94667H12.0267V5.96H1.57333L5.73333 10.0667L4.98667 10.8133L0.0266666 5.8V5.10667L4.98667 0.0933332Z"
+                        fill="#21A2FF"
+                    />
+                </svg>
+            </button>
             <div class="auth-container-section">
                 <div class="existing-logins" v-if="existingLogins.length > 0 && app === 'AMAZONQ'">
                     <div class="title">Connect with an existing account:</div>
@@ -299,7 +307,11 @@ export default defineComponent({
             }
         },
         handleBackButtonClick() {
-            this.stage = 'START'
+            if (this.stage === 'START') {
+                void client.quitLoginScreen()
+            } else {
+                this.stage = 'START'
+            }
         },
         async handleContinueClick() {
             if (this.stage === 'START') {

--- a/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
+++ b/packages/core/src/login/webview/vue/toolkit/backend_toolkit.ts
@@ -72,4 +72,8 @@ export class ToolkitLoginWebview extends CommonAuthWebview {
     async useConnection(connectionId: string): Promise<AuthError | undefined> {
         return undefined
     }
+
+    async quitLoginScreen() {
+        await vscode.commands.executeCommand('setContext', 'aws.explorer.showAuthView', false)
+    }
 }


### PR DESCRIPTION
## Problem
1. User cannot easily quit the login screen
2. Code catalyst login should be under Workforce button

## Solution
1 Add back arrow at login start screen ONLY for aws toolkit
<img width="544" alt="Screenshot 2024-03-25 at 2 45 16 PM" src="https://github.com/hayemaxi/aws-toolkit-vscode/assets/97199248/2356799f-7a73-40f2-97cd-8a16d4317d77">

2. Move code catalyst under Workforce button login screen

<!---
    REMINDER:
    - Read CONTRIBUTING.md first.
    - Add test coverage for your changes.
    - Update the changelog using `npm run newChange`.
    - Link to related issues/commits.
    - Testing: how did you test your changes?
    - Screenshots
-->

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
